### PR TITLE
adding registry.xml config to start and stop indexing processes

### DIFF
--- a/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/IndexingConstants.java
+++ b/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/IndexingConstants.java
@@ -25,9 +25,13 @@ import org.wso2.carbon.registry.core.RegistryConstants;
  */
 public final class IndexingConstants {
 
+
     // Make the constructor private, since it is a utility class
     private IndexingConstants() {
     }
+
+    // Default value to determine whether to start indexers or not
+    public static final boolean START_INDEXING_DEFAULT_VALUE = true;
 
     // Default last access time location path is set as default when nothing specified in registry.xml
     public static final String LAST_ACCESS_TIME_LOCATION = RegistryConstants.LOCAL_REPOSITORY_BASE_PATH +

--- a/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/IndexingManager.java
+++ b/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/IndexingManager.java
@@ -77,13 +77,15 @@ public class IndexingManager {
 
     public synchronized void startIndexing() {
         stopIndexing(); //stop executors if they are already running, otherwise they will never stop
-        submittingExecutor = Executors.newSingleThreadScheduledExecutor();
-        submittingExecutor.scheduleWithFixedDelay(new ResourceSubmitter(this),
-                getStartingDelayInSecs(), getIndexingFreqInSecs(), TimeUnit.SECONDS);
+        if (registryConfig.IsStartIndexing()) {
+            submittingExecutor = Executors.newSingleThreadScheduledExecutor();
+            submittingExecutor.scheduleWithFixedDelay(new ResourceSubmitter(this),
+                    getStartingDelayInSecs(), getIndexingFreqInSecs(), TimeUnit.SECONDS);
 
-        indexingExecutor = Executors.newSingleThreadScheduledExecutor();
-        indexingExecutor.scheduleWithFixedDelay(indexer, getStartingDelayInSecs(),getIndexingFreqInSecs(), TimeUnit.SECONDS);
-        readLastAccessTime();
+            indexingExecutor = Executors.newSingleThreadScheduledExecutor();
+            indexingExecutor.scheduleWithFixedDelay(indexer, getStartingDelayInSecs(), getIndexingFreqInSecs(), TimeUnit.SECONDS);
+            readLastAccessTime();
+        }
     }
 
     public synchronized void restartIndexing() {

--- a/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/RegistryConfigLoader.java
+++ b/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/RegistryConfigLoader.java
@@ -44,6 +44,8 @@ public class RegistryConfigLoader {
 
     private static Log log = LogFactory.getLog(RegistryConfigLoader.class);
 
+    private boolean startIndexing;
+
     private long startingDelayInSecs;
 
     private long indexingFreqInSecs;
@@ -74,6 +76,7 @@ public class RegistryConfigLoader {
     }
 
     private RegistryConfigLoader() {
+        startIndexing = IndexingConstants.START_INDEXING_DEFAULT_VALUE;
         startingDelayInSecs = IndexingConstants.STARTING_DELAY_IN_SECS_DEFAULT_VALUE;
         indexingFreqInSecs = IndexingConstants.INDEXING_FREQ_IN_SECS_DEFAULT_VALUE;
         lastAccessTimeLocation = IndexingConstants.LAST_ACCESS_TIME_LOCATION;
@@ -122,6 +125,10 @@ public class RegistryConfigLoader {
         return exclusionList.toArray(new Pattern[exclusionList.size()]);
     }
 
+    public boolean IsStartIndexing() {
+        return startIndexing;
+    }
+
     public long getStartingDelayInSecs() {
         return startingDelayInSecs;
     }
@@ -146,6 +153,17 @@ public class RegistryConfigLoader {
     }
 
     private void loadIndexingConfiguration(OMElement indexingConfig){
+        OMElement startIndexingConfig = indexingConfig.getFirstChildWithName(new QName("startIndexing"));
+        if (startIndexingConfig != null) {
+            try {
+                startIndexing = Boolean.parseBoolean(startIndexingConfig.getText());
+            } catch (OMException e) {
+                // we can use default value and continue if no OMElement found in indexingConfig
+                log.error("Error occurred when retrieving startIndexing, hence using the default value '" +
+                        startIndexing + "'", e);
+            }
+        }
+
         try {
             startingDelayInSecs = Long.parseLong(indexingConfig.getFirstChildWithName(
                     new QName("startingDelayInSeconds")).getText());


### PR DESCRIPTION
These code changes are to restrict a carbon product from running indexing processes if needed.

* By adding \<startIndexing\>false\</startIndexing\> element inside \<indexingConfiguration\> user will be able to stop indexing processes from running.
* If this config element is not present in the registry.xml, carbon server will by default start indexing threads.
