### PR TITLE
Swagger doc for G-Reg registry REST API.

### DIFF
--- a/components/registry/org.wso2.carbon.registry.rest.api/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.rest.api/pom.xml
@@ -104,6 +104,21 @@
             <artifactId>org.eclipse.persistence.moxy</artifactId>
             <version>2.5.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.wordnik</groupId>
+            <artifactId>swagger-jaxrs_2.10</artifactId>
+            <version>1.3.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <pluginManagement>

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Artifact.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Artifact.java
@@ -15,6 +15,10 @@
  */
 package org.wso2.carbon.registry.rest.api;
 
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -25,7 +29,14 @@ import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.rest.api.security.RestAPIAuthContext;
 import org.wso2.carbon.registry.rest.api.security.RestAPISecurityUtils;
 
-import javax.ws.rs.*;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.Response;
 import java.io.InputStream;
@@ -36,6 +47,9 @@ import java.util.List;
  */
 
 @Path("/artifact")
+@Api(value = "/artifact",
+     description = "Rest api for doing operations on a resource",
+     produces = MediaType.APPLICATION_JSON)
 public class Artifact extends RegistryRestSuper {
 
     private Log log = LogFactory.getLog(Artifact.class);
@@ -52,6 +66,13 @@ public class Artifact extends RegistryRestSuper {
     @GET
     @Path("/{path:.*}")
     @Produces("application/octet-stream")
+    @ApiOperation(value = "Get content of a resource",
+                  httpMethod = "GET",
+                  notes = "Fetch content of a resource")//TODO add return type based on resource or collection
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the resource content and returned in body"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getResource(@PathParam("path") List<PathSegment> path, @HeaderParam("X-JWT-Assertion") String JWTToken) {
 
         PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
@@ -101,6 +122,14 @@ public class Artifact extends RegistryRestSuper {
     @PUT
     @Path("/{path:.*}")
     @Produces("application/json")
+    @ApiOperation(value = "Create/Update a resource",
+                  httpMethod = "PUT",
+                  notes = "Create/Update a resource")
+    @ApiResponses(value = { @ApiResponse(code = 201, message = "Comment updated successfully"),
+                            @ApiResponse(code = 400, message = "Media type mismatch"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response createResource(@PathParam("path") List<PathSegment> path,
                                    InputStream contentStream,
                                    @HeaderParam("Content-Type") String contentType,
@@ -167,6 +196,13 @@ public class Artifact extends RegistryRestSuper {
     @DELETE
     @Path("/{path:.*}")
     @Produces("application/json")
+    @ApiOperation(value = "Delete a resource",
+                  httpMethod = "DELETE",
+                  notes = "Delete a resource")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Resource deleted successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response deleteResource(@PathParam("path") List<PathSegment> path,
                                    @HeaderParam("X-JWT-Assertion") String JWTToken) {
 

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Artifact.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Artifact.java
@@ -71,7 +71,7 @@ public class Artifact extends RegistryRestSuper {
                   notes = "Fetch content of a resource")//TODO add return type based on resource or collection
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the resource content and returned in body"),
                             @ApiResponse(code = 401, message = "Invalid credentials provided"),
-                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 404, message = "Given specific resource not found"),
                             @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getResource(@PathParam("path") List<PathSegment> path, @HeaderParam("X-JWT-Assertion") String JWTToken) {
 
@@ -125,7 +125,7 @@ public class Artifact extends RegistryRestSuper {
     @ApiOperation(value = "Create/Update a resource",
                   httpMethod = "PUT",
                   notes = "Create/Update a resource")
-    @ApiResponses(value = { @ApiResponse(code = 201, message = "Comment updated successfully"),
+    @ApiResponses(value = { @ApiResponse(code = 201, message = "Resource updated successfully"),
                             @ApiResponse(code = 400, message = "Media type mismatch"),
                             @ApiResponse(code = 401, message = "Invalid credentials provided"),
                             @ApiResponse(code = 404, message = "Specified resource not found"),

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Association.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Association.java
@@ -15,22 +15,34 @@
  */
 package org.wso2.carbon.registry.rest.api;
 
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
-import org.wso2.carbon.registry.rest.api.model.AssociationModel;
 import org.wso2.carbon.registry.rest.api.security.RestAPIAuthContext;
 import org.wso2.carbon.registry.rest.api.security.RestAPISecurityUtils;
 
-import javax.ws.rs.*;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 /**
  * This class is to handle the association related REST verbs POST and DELETE.
  */
 @Path("/association")
+@Api(value = "/association",
+     description = "Rest api for doing operations on an association",
+     produces = MediaType.APPLICATION_JSON)
 public class Association extends RegistryRestSuper {
 
     private Log log = LogFactory.getLog(Association.class);
@@ -44,6 +56,13 @@ public class Association extends RegistryRestSuper {
      */
     @POST
     @Produces("application/json")
+    @ApiOperation(value = "Add an association between two resources",
+                  httpMethod = "POST",
+                  notes = "Add an association between two resources")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Association added successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response addAssociation(@QueryParam("path") String sourcePath,
                                    @QueryParam("targetPath") String targetPath,
                                    @QueryParam("type") String type,
@@ -80,6 +99,13 @@ public class Association extends RegistryRestSuper {
      */
     @DELETE
     @Produces("application/json")
+    @ApiOperation(value = "Delete an association",
+                  httpMethod = "DELETE",
+                  notes = "Delete an association")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Association deleted successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response deleteAssociation(@QueryParam("path") String sourcePath,
                                       @QueryParam("targetPath") String targetPath,
                                       @QueryParam("type") String type,

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Associations.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Associations.java
@@ -16,6 +16,10 @@
 
 package org.wso2.carbon.registry.rest.api;
 
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -26,7 +30,14 @@ import org.wso2.carbon.registry.rest.api.model.AssociationModel;
 import org.wso2.carbon.registry.rest.api.security.RestAPIAuthContext;
 import org.wso2.carbon.registry.rest.api.security.RestAPISecurityUtils;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +46,9 @@ import java.util.List;
  * his class is to handle the associations related REST verb GET.
  */
 @Path("/associations")
+@Api(value = "/associations",
+     description = "Rest api for doing operations on associations",
+     produces = MediaType.APPLICATION_JSON)
 public class Associations extends PaginationCalculation<Association> {
 
     private Log log = LogFactory.getLog(Associations.class);
@@ -50,6 +64,13 @@ public class Associations extends PaginationCalculation<Association> {
     @POST
     @Consumes("application/json")
     @Produces("application/json")
+    @ApiOperation(value = "Add a set of associations to a resource",
+                  httpMethod = "POST",
+                  notes = "Add a set of associations to a resource")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Associations added successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response addAssociations(@QueryParam("path") String sourcePath, AssociationModel[] association,
                                     @HeaderParam("X-JWT-Assertion") String JWTToken) {
 
@@ -88,6 +109,15 @@ public class Associations extends PaginationCalculation<Association> {
      */
     @GET
     @Produces("application/json")
+    @ApiOperation(value = "Get all associations on a resource",
+                  httpMethod = "GET",
+                  notes = "Fetch all associations on a resource",
+                  response = AssociationModel.class,
+                  responseContainer = "List")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the comments and returned in body"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getAssociations(@QueryParam("path") String sourcePath,
                                     @QueryParam("type") String type,
                                     @QueryParam("start") int start,

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Associations.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Associations.java
@@ -114,9 +114,9 @@ public class Associations extends PaginationCalculation<Association> {
                   notes = "Fetch all associations on a resource",
                   response = AssociationModel.class,
                   responseContainer = "List")
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the comments and returned in body"),
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the associations and returned in body"),
                             @ApiResponse(code = 401, message = "Invalid credentials provided"),
-                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 404, message = "Associations for given resource were not found"),
                             @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getAssociations(@QueryParam("path") String sourcePath,
                                     @QueryParam("type") String type,

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Comment.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Comment.java
@@ -15,9 +15,12 @@
  */
 package org.wso2.carbon.registry.rest.api;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.Response;
-
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiImplicitParam;
+import com.wordnik.swagger.annotations.ApiImplicitParams;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -27,10 +30,25 @@ import org.wso2.carbon.registry.rest.api.model.CommentModel;
 import org.wso2.carbon.registry.rest.api.security.RestAPIAuthContext;
 import org.wso2.carbon.registry.rest.api.security.RestAPISecurityUtils;
 
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 /**
  * This class is to handle REST verbs GET , PSST and DELETE.
  */
 @Path("/comment")
+@Api(value = "/comment",
+     description = "Rest api for doing operations on a single comment",
+     produces = MediaType.APPLICATION_JSON)
+//@Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
 public class Comment extends RegistryRestSuper {
 
     private Log log = LogFactory.getLog(Comment.class);
@@ -44,6 +62,18 @@ public class Comment extends RegistryRestSuper {
      */
     @GET
     @Produces("application/json")
+    @ApiOperation(value = "Get specific comment",
+                  httpMethod = "GET",
+                  notes = "Fetch details about a specific comment",
+                  response = CommentModel.class)
+    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization",
+                                         value = "Header to provide basic authentication value",
+                                         dataType = "string",
+                                         paramType = "header") })
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the specific comment and returned in body"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getComment(@QueryParam("path") String resourcePath,
                                @QueryParam("id") long commentId,
                                @HeaderParam("X-JWT-Assertion") String JWTToken) {
@@ -91,6 +121,13 @@ public class Comment extends RegistryRestSuper {
      */
     @POST
     @Produces("application/json")
+    @ApiOperation(value = "Add a comment to a resource",
+                  httpMethod = "POST",
+                  notes = "Add a comment to a resource")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Comment added successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response addComment(@QueryParam("path") String resourcePath,
                                String commentText,
                                @HeaderParam("X-JWT-Assertion") String JWTToken) {
@@ -126,6 +163,13 @@ public class Comment extends RegistryRestSuper {
      */
     @PUT
     @Produces("application/json")
+    @ApiOperation(value = "Update an already added comment",
+                  httpMethod = "PUT",
+                  notes = "Update an already added comment")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Comment updated successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response editComment(@QueryParam("path") String resourcePath,
                                 @QueryParam("id") long commentId, String commentText,
                                 @HeaderParam("X-JWT-Assertion") String JWTToken) {
@@ -162,6 +206,13 @@ public class Comment extends RegistryRestSuper {
      */
     @DELETE
     @Produces("application/json")
+    @ApiOperation(value = "Delete a comment",
+                  httpMethod = "DELETE",
+                  notes = "Delete a comment")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Comment deleted successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response deleteComment(@QueryParam("path") String resourcePath,
                                   @QueryParam("id") long commentId,
                                   @HeaderParam("X-JWT-Assertion") String JWTToken) {

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Comment.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Comment.java
@@ -16,8 +16,6 @@
 package org.wso2.carbon.registry.rest.api;
 
 import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiImplicitParam;
-import com.wordnik.swagger.annotations.ApiImplicitParams;
 import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiResponse;
 import com.wordnik.swagger.annotations.ApiResponses;
@@ -66,10 +64,6 @@ public class Comment extends RegistryRestSuper {
                   httpMethod = "GET",
                   notes = "Fetch details about a specific comment",
                   response = CommentModel.class)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization",
-                                         value = "Header to provide basic authentication value",
-                                         dataType = "string",
-                                         paramType = "header") })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the specific comment and returned in body"),
                             @ApiResponse(code = 401, message = "Invalid credentials provided"),
                             @ApiResponse(code = 404, message = "Given specific comment not found"),

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Comments.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Comments.java
@@ -15,6 +15,10 @@
  */
 package org.wso2.carbon.registry.rest.api;
 
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -26,6 +30,7 @@ import org.wso2.carbon.registry.rest.api.security.RestAPIAuthContext;
 import org.wso2.carbon.registry.rest.api.security.RestAPISecurityUtils;
 
 import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +39,9 @@ import java.util.List;
  * This class retrieves the comments of the requested resource.
  */
 @Path("/comments")
+@Api(value = "/comments",
+     description = "Rest api for doing operations on comments",
+     produces = MediaType.APPLICATION_JSON)
 public class Comments extends PaginationCalculation<Comment> {
 
     private Log log = LogFactory.getLog(Comments.class);
@@ -48,6 +56,15 @@ public class Comments extends PaginationCalculation<Comment> {
      */
     @GET
     @Produces("application/json")
+    @ApiOperation(value = "Get all comments on a resource",
+                  httpMethod = "GET",
+                  notes = "Fetch all comments on a resource",
+                  response = CommentModel.class,
+                  responseContainer = "List")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the comments and returned in body"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getComments(@QueryParam("path") String resourcePath,
                                 @QueryParam("start") int start,
                                 @QueryParam("size") int size,

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Copy.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Copy.java
@@ -16,6 +16,10 @@
 
 package org.wso2.carbon.registry.rest.api;
 
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -28,6 +32,7 @@ import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 
@@ -35,6 +40,9 @@ import javax.ws.rs.core.Response;
  * This class to handle resource copy functions according to the REST verbs.
  */
 @Path("/copy")
+@Api(value = "/copy",
+     description = "Rest api for doing copy operations on resources",
+     produces = MediaType.APPLICATION_JSON)
 public class Copy extends RegistryRestSuper {
     Log log = LogFactory.getLog(Copy.class);
 
@@ -47,6 +55,13 @@ public class Copy extends RegistryRestSuper {
      * @return - HTTP 204 No Content if success.
      */
     @POST
+    @ApiOperation(value = "Copy source resource to target path",
+                  httpMethod = "POST",
+                  notes = "Copy source resource to target path")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Resource copied successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response copyResource(@QueryParam("path") String resourcePath,
                                  @QueryParam("destination") String destinationPath,
                                  @HeaderParam("X-JWT-Assertion") String JWTToken) {

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/MetaData.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/MetaData.java
@@ -57,13 +57,13 @@ public class MetaData extends RegistryRestSuper {
      */
     @GET
     @Produces("application/json")
-    @ApiOperation(value = "Get specific comment",
+    @ApiOperation(value = "Get metadata about a specific resource",
                   httpMethod = "GET",
-                  notes = "Fetch details about a specific comment",
+                  notes = "Fetch metadata about a specific resource",
                   response = ResourceModel.class)
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the specific comment and returned in body"),
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Found metadata for the resource and returned in body"),
                             @ApiResponse(code = 401, message = "Invalid credentials provided"),
-                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 404, message = "Given specific resource not found"),
                             @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getMetaData(@QueryParam("path") String resourcePath,
                                 @HeaderParam("X-JWT-Assertion") String JWTToken) {

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/MetaData.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/MetaData.java
@@ -16,6 +16,10 @@
 
 package org.wso2.carbon.registry.rest.api;
 
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -26,13 +30,21 @@ import org.wso2.carbon.registry.rest.api.model.ResourceModel;
 import org.wso2.carbon.registry.rest.api.security.RestAPIAuthContext;
 import org.wso2.carbon.registry.rest.api.security.RestAPISecurityUtils;
 
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 /**
  * This class is to get the meta data of the resource using REST verb GET.
  */
 @Path("/metadata")
+@Api(value = "/metadata",
+     description = "Rest api for doing operations on metadata related to resources",
+     produces = MediaType.APPLICATION_JSON)
 public class MetaData extends RegistryRestSuper {
 
     private Log log = LogFactory.getLog(MetaData.class);
@@ -45,6 +57,14 @@ public class MetaData extends RegistryRestSuper {
      */
     @GET
     @Produces("application/json")
+    @ApiOperation(value = "Get specific comment",
+                  httpMethod = "GET",
+                  notes = "Fetch details about a specific comment",
+                  response = ResourceModel.class)
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the specific comment and returned in body"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getMetaData(@QueryParam("path") String resourcePath,
                                 @HeaderParam("X-JWT-Assertion") String JWTToken) {
 

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Move.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Move.java
@@ -16,6 +16,10 @@
 
 package org.wso2.carbon.registry.rest.api;
 
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
@@ -26,12 +30,16 @@ import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 /**
  * This class is to handle resource move operation according to the REST verb POST.
  */
 @Path("/move")
+@Api(value = "/move",
+     description = "Rest api for doing move operations on resources",
+     produces = MediaType.APPLICATION_JSON)
 public class Move extends RegistryRestSuper {
 
     /**
@@ -43,6 +51,13 @@ public class Move extends RegistryRestSuper {
      */
 
     @POST
+    @ApiOperation(value = "Move source resource to target path",
+                  httpMethod = "POST",
+                  notes = "Move source resource to target path")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Resource moved successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response moveResource(@QueryParam("path") String resourcePath,
                                  @QueryParam("destination") String destinationPath,
                                  @HeaderParam("X-JWT-Assertion") String JWTToken) {

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Properties.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Properties.java
@@ -18,6 +18,10 @@ package org.wso2.carbon.registry.rest.api;
 
 //import edu.emory.mathcs.backport.java.util.Arrays;
 
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -28,7 +32,14 @@ import org.wso2.carbon.registry.rest.api.model.PropertyModel;
 import org.wso2.carbon.registry.rest.api.security.RestAPIAuthContext;
 import org.wso2.carbon.registry.rest.api.security.RestAPISecurityUtils;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,6 +50,9 @@ import java.util.List;
  * This class handle the properties related to the REST verbs GET,POST and DELETE.
  */
 @Path("/properties")
+@Api(value = "/properties",
+     description = "Rest api for doing operations on resource properties",
+     produces = MediaType.APPLICATION_JSON)
 public class Properties extends PaginationCalculation<PropertyModel> {
 
     private Log log = LogFactory.getLog(Properties.class);
@@ -53,6 +67,15 @@ public class Properties extends PaginationCalculation<PropertyModel> {
      */
     @GET
     @Produces("application/json")
+    @ApiOperation(value = "Get all properties on a resource",
+                  httpMethod = "GET",
+                  notes = "Fetch all properties on a resource",
+                  response = PropertyModel.class,
+                  responseContainer = "List")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the properties and returned in body"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getProperties(@QueryParam("path") String resourcePath,
                                   @QueryParam("start") int start,
                                   @QueryParam("size") int size,
@@ -88,6 +111,13 @@ public class Properties extends PaginationCalculation<PropertyModel> {
      */
     @POST
     @Consumes("application/json")
+    @ApiOperation(value = "Add properties to a resource",
+                  httpMethod = "POST",
+                  notes = "Add properties to a resource")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Properties added successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response addProperties(@QueryParam("path") String resourcePath,
                                   PropertyModel[] addProperty,
                                   @HeaderParam("X-JWT-Assertion") String JWTToken) {

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Properties.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Properties.java
@@ -74,7 +74,7 @@ public class Properties extends PaginationCalculation<PropertyModel> {
                   responseContainer = "List")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the properties and returned in body"),
                             @ApiResponse(code = 401, message = "Invalid credentials provided"),
-                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 404, message = "Given specific resource not found"),
                             @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getProperties(@QueryParam("path") String resourcePath,
                                   @QueryParam("start") int start,

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Property.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Property.java
@@ -70,7 +70,7 @@ public class Property extends RegistryRestSuper {
                   response = PropertyModel.class)
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the specific property and returned in body"),
                             @ApiResponse(code = 401, message = "Invalid credentials provided"),
-                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 404, message = "Given specific resource not found"),
                             @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getProperty(@QueryParam("path") String resourcePath,
                                 @QueryParam("name") String propertyName,

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Property.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Property.java
@@ -16,6 +16,10 @@
 
 package org.wso2.carbon.registry.rest.api;
 
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -26,7 +30,15 @@ import org.wso2.carbon.registry.rest.api.model.PropertyModel;
 import org.wso2.carbon.registry.rest.api.security.RestAPIAuthContext;
 import org.wso2.carbon.registry.rest.api.security.RestAPISecurityUtils;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.Properties;
@@ -36,6 +48,9 @@ import java.util.Properties;
  */
 
 @Path("/property")
+@Api(value = "/property",
+     description = "Rest api for doing operations on a specific single property",
+     produces = MediaType.APPLICATION_JSON)
 public class Property extends RegistryRestSuper {
 
     private Log log = LogFactory.getLog(Property.class);
@@ -49,6 +64,14 @@ public class Property extends RegistryRestSuper {
      */
     @GET
     @Produces("application/json")
+    @ApiOperation(value = "Get specific property",
+                  httpMethod = "GET",
+                  notes = "Fetch details about a specific property",
+                  response = PropertyModel.class)
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the specific property and returned in body"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getProperty(@QueryParam("path") String resourcePath,
                                 @QueryParam("name") String propertyName,
                                 @HeaderParam("X-JWT-Assertion") String JWTToken) {
@@ -90,6 +113,13 @@ public class Property extends RegistryRestSuper {
      */
     @POST
     @Consumes("application/json")
+    @ApiOperation(value = "Add a property to a resource",
+                  httpMethod = "POST",
+                  notes = "Add a property to a resource")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "property added successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response addProperty(@QueryParam("path") String resourcePath,
                                 @QueryParam("name") String name,
                                 @QueryParam("value") String value,
@@ -129,6 +159,13 @@ public class Property extends RegistryRestSuper {
      */
     @DELETE
     @Produces("application/json")
+    @ApiOperation(value = "Delete a property",
+                  httpMethod = "DELETE",
+                  notes = "Delete a property")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "property deleted successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response deleteProperty(@QueryParam("path") String resourcePath,
                                    @QueryParam("name") String name,
                                    @HeaderParam("X-JWT-Assertion") String JWTToken) {

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Rate.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Rate.java
@@ -16,6 +16,10 @@
 
 package org.wso2.carbon.registry.rest.api;
 
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -25,12 +29,16 @@ import org.wso2.carbon.registry.rest.api.security.RestAPIAuthContext;
 import org.wso2.carbon.registry.rest.api.security.RestAPISecurityUtils;
 
 import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 /**
  * This class to handle the rate relate REST verbs POST
  */
 @Path("/rate")
+@Api(value = "/rate",
+     description = "Rest api to rate a resource",
+     produces = MediaType.APPLICATION_JSON)
 public class Rate extends RegistryRestSuper {
 
     private Log log = LogFactory.getLog(Rate.class);
@@ -44,6 +52,14 @@ public class Rate extends RegistryRestSuper {
      */
     @POST
     @Produces("application/json")
+    @ApiOperation(value = "Add a rate to a resource",
+                  httpMethod = "POST",
+                  notes = "Add a rate to a resource",
+                  response = float.class)
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Rate added successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response rateResource(@QueryParam("path") String resourcePath,
                                  @QueryParam("value") int value,
                                  @HeaderParam("X-JWT-Assertion") String JWTToken) {

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Rating.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Rating.java
@@ -15,9 +15,10 @@
  */
 package org.wso2.carbon.registry.rest.api;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.Response;
-
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -27,10 +28,22 @@ import org.wso2.carbon.registry.rest.api.model.RatingModel;
 import org.wso2.carbon.registry.rest.api.security.RestAPIAuthContext;
 import org.wso2.carbon.registry.rest.api.security.RestAPISecurityUtils;
 
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 /**
  * This class is to handle the rating related REST verbs GET,DELETE.
  */
 @Path("/rating")
+@Api(value = "/rating",
+     description = "Rest api for operating on a  rating a resource",
+     produces = MediaType.APPLICATION_JSON)
 public class Rating extends RegistryRestSuper {
 
     private Log log = LogFactory.getLog(Rating.class);
@@ -43,6 +56,15 @@ public class Rating extends RegistryRestSuper {
      */
     @GET
     @Produces("application/json")
+    @ApiOperation(value = "Get user's rating and overall rating on a resource",
+                  httpMethod = "GET",
+                  notes = "Fetch user's rating and overall rating on a resource",
+                  response = RatingModel.class)
+    @ApiResponses(value = { @ApiResponse(code = 200,
+                                         message = "Found user's rating and overall rating and returned in body"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getRating(@QueryParam("path") String resourcePath,
                               @HeaderParam("X-JWT-Assertion") String JWTToken) {
 
@@ -78,6 +100,13 @@ public class Rating extends RegistryRestSuper {
      */
     @DELETE
     @Produces("application/json")
+    @ApiOperation(value = "Delete the user's rating on the given resource",
+                  httpMethod = "DELETE",
+                  notes = "Delete the user's rating on the given resource")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "User's rating deleted successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response removeRating(@QueryParam("path") String resourcePath,
                                  @HeaderParam("X-JWT-Assertion") String JWTToken) {
         RestAPIAuthContext authContext = RestAPISecurityUtils.getAuthContext

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Rating.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Rating.java
@@ -63,7 +63,7 @@ public class Rating extends RegistryRestSuper {
     @ApiResponses(value = { @ApiResponse(code = 200,
                                          message = "Found user's rating and overall rating and returned in body"),
                             @ApiResponse(code = 401, message = "Invalid credentials provided"),
-                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 404, message = "Given specific resource not found"),
                             @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getRating(@QueryParam("path") String resourcePath,
                               @HeaderParam("X-JWT-Assertion") String JWTToken) {

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Revision.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Revision.java
@@ -59,7 +59,7 @@ public class Revision extends RegistryRestSuper {
                   notes = "Fetch content of a resource")//TODO add return type based on resource or collection
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the revisioned resource content and returned in body"),
                             @ApiResponse(code = 401, message = "Invalid credentials provided"),
-                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 404, message = "Given specific resource not found"),
                             @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getRevision(@QueryParam("path") String path,
                                 @QueryParam("id") long revisionId,

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Revision.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Revision.java
@@ -16,6 +16,10 @@
 
 package org.wso2.carbon.registry.rest.api;
 
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -27,6 +31,7 @@ import org.wso2.carbon.registry.rest.api.security.RestAPIAuthContext;
 import org.wso2.carbon.registry.rest.api.security.RestAPISecurityUtils;
 
 import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 /**
@@ -34,6 +39,9 @@ import javax.ws.rs.core.Response;
  */
 
 @Path("/revision")
+@Api(value = "/revision",
+     description = "Rest api for doing operations on a resource revision",
+     produces = MediaType.APPLICATION_JSON)
 public class Revision extends RegistryRestSuper {
 
     private Log log = LogFactory.getLog(Revision.class);
@@ -46,6 +54,13 @@ public class Revision extends RegistryRestSuper {
      */
     @GET
     @Produces("application/octet-stream")
+    @ApiOperation(value = "Get content of a resource revision",
+                  httpMethod = "GET",
+                  notes = "Fetch content of a resource")//TODO add return type based on resource or collection
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the revisioned resource content and returned in body"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getRevision(@QueryParam("path") String path,
                                 @QueryParam("id") long revisionId,
                                 @HeaderParam("X-JWT-Assertion") String JWTToken) {
@@ -85,6 +100,13 @@ public class Revision extends RegistryRestSuper {
      */
     @POST
     @Produces("application/json")
+    @ApiOperation(value = "Create a resource revision",
+                  httpMethod = "POST",
+                  notes = "Create a resource revision")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Resource revision created successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response createRevision(@QueryParam("path") String path,
                                    @HeaderParam("X-JWT-Assertion") String JWTToken) {
 
@@ -115,6 +137,13 @@ public class Revision extends RegistryRestSuper {
      */
     @DELETE
     @Produces("application/json")
+    @ApiOperation(value = "Delete a resource revision",
+                  httpMethod = "DELETE",
+                  notes = "Delete a resource revision")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Resource revision deleted successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response deleteRevision(@QueryParam("path") String path,
                                    @QueryParam("id") long versionID,
                                    @HeaderParam("X-JWT-Assertion") String JWTToken) {

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Revisions.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Revisions.java
@@ -65,7 +65,7 @@ public class Revisions extends PaginationCalculation<String> {
                   responseContainer = "List")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the revisions IDs and returned in body"),
                             @ApiResponse(code = 401, message = "Invalid credentials provided"),
-                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 404, message = "Given specific resource not found"),
                             @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getRevisions(@QueryParam("path") String path,
                                  @QueryParam("start") int start,

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Revisions.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Revisions.java
@@ -17,6 +17,10 @@
 package org.wso2.carbon.registry.rest.api;
 
 
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -25,13 +29,21 @@ import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.rest.api.security.RestAPIAuthContext;
 import org.wso2.carbon.registry.rest.api.security.RestAPISecurityUtils;
 
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 /**
  * This class is to handle the revisions of the given resource according to the REST verb GET.
  */
 @Path("/revisions")
+@Api(value = "/revisions",
+     description = "Rest api for doing operations on resource revisions",
+     produces = MediaType.APPLICATION_JSON)
 public class Revisions extends PaginationCalculation<String> {
 
     private Log log = LogFactory.getLog(Revisions.class);
@@ -46,6 +58,15 @@ public class Revisions extends PaginationCalculation<String> {
      */
     @GET
     @Produces("application/json")
+    @ApiOperation(value = "Get all revisions of a resource",
+                  httpMethod = "GET",
+                  notes = "Fetch all revisions of a resource",
+                  response = String.class,
+                  responseContainer = "List")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the revisions IDs and returned in body"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getRevisions(@QueryParam("path") String path,
                                  @QueryParam("start") int start,
                                  @QueryParam("size") int size,

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Tag.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Tag.java
@@ -16,6 +16,10 @@
 
 package org.wso2.carbon.registry.rest.api;
 
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
@@ -26,10 +30,17 @@ import org.wso2.carbon.registry.rest.api.model.TaggedResourcePathModel;
 import org.wso2.carbon.registry.rest.api.security.RestAPIAuthContext;
 import org.wso2.carbon.registry.rest.api.security.RestAPISecurityUtils;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -37,6 +48,9 @@ import java.util.List;
  */
 
 @Path("/tag")
+@Api(value = "/tag",
+     description = "Rest api for doing operations on a specific single tag",
+     produces = MediaType.APPLICATION_JSON)
 public class Tag extends PaginationCalculation<TaggedResourcePath> {
 
     private Log log = LogFactory.getLog(Tag.class);
@@ -53,6 +67,14 @@ public class Tag extends PaginationCalculation<TaggedResourcePath> {
      */
     @GET
     @Produces("application/json")
+    @ApiOperation(value = "Get resource paths tagged with a specific tag",
+                  httpMethod = "GET",
+                  notes = "Fetch resource paths tagged with a specific tag",
+                  response = TaggedResourcePathModel.class,
+                  responseContainer = "List")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the tagged resource paths and returned in body"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getTaggedResources(@QueryParam("name") String tagName,
                                        @QueryParam("start") int start,
                                        @QueryParam("size") int size,
@@ -85,6 +107,13 @@ public class Tag extends PaginationCalculation<TaggedResourcePath> {
     @POST
     @Consumes("application/json")
     @Produces("application/json")
+    @ApiOperation(value = "Add a tag to a resource",
+                  httpMethod = "POST",
+                  notes = "Add a tag to a resource")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Resource tagged successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response addTag(@QueryParam("path") String resourcePath,
                            @QueryParam("name") String tagText,
                            @HeaderParam("X-JWT-Assertion") String JWTToken) {
@@ -120,6 +149,13 @@ public class Tag extends PaginationCalculation<TaggedResourcePath> {
      */
     @DELETE
     @Produces("application/json")
+    @ApiOperation(value = "Delete a tag",
+                  httpMethod = "DELETE",
+                  notes = "Delete a tag")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Tag deleted successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response deleteTag(@QueryParam("path") String resourcePath,
                               @QueryParam("name") String tagName,
                               @HeaderParam("X-JWT-Assertion") String JWTToken) {

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Tags.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Tags.java
@@ -16,22 +16,42 @@
 
 package org.wso2.carbon.registry.rest.api;
 
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.registry.core.Collection;
-import org.wso2.carbon.registry.core.*;
+import org.wso2.carbon.registry.core.Registry;
+import org.wso2.carbon.registry.core.RegistryConstants;
+import org.wso2.carbon.registry.core.Resource;
 import org.wso2.carbon.registry.core.Tag;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.rest.api.model.TagModel;
 import org.wso2.carbon.registry.rest.api.security.RestAPIAuthContext;
 import org.wso2.carbon.registry.rest.api.security.RestAPISecurityUtils;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 
 @Path("/tags")
+@Api(value = "/tags",
+     description = "Rest api for doing operations on tags",
+     produces = MediaType.APPLICATION_JSON)
 public class Tags extends PaginationCalculation<Tag> {
 
     private Log log = LogFactory.getLog(Tags.class);
@@ -46,6 +66,14 @@ public class Tags extends PaginationCalculation<Tag> {
      */
     @GET
     @Produces("application/json")
+    @ApiOperation(value = "Get all comments on a resource",
+                  httpMethod = "GET",
+                  notes = "Fetch all comments on a resource",
+                  response = TagModel.class)
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the tags and returned in body"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getTags(@QueryParam("path") String resourcePath,
                             @QueryParam("start") int start,
                             @QueryParam("size") int size,
@@ -89,6 +117,13 @@ public class Tags extends PaginationCalculation<Tag> {
     @POST
     @Consumes("application/json")
     @Produces("application/json")
+    @ApiOperation(value = "Add an array of tags to a resource",
+                  httpMethod = "POST",
+                  notes = "Add an array of tags to a resource")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Resource tagged successfully"),
+                            @ApiResponse(code = 401, message = "Invalid credentials provided"),
+                            @ApiResponse(code = 404, message = "Specified resource not found"),
+                            @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response addTags(@QueryParam("path") String resourcePath,
                             TagModel tags,
                             @HeaderParam("X-JWT-Assertion") String JWTToken) {

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Tags.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Tags.java
@@ -66,13 +66,13 @@ public class Tags extends PaginationCalculation<Tag> {
      */
     @GET
     @Produces("application/json")
-    @ApiOperation(value = "Get all comments on a resource",
+    @ApiOperation(value = "Get all tags on a resource",
                   httpMethod = "GET",
-                  notes = "Fetch all comments on a resource",
+                  notes = "Fetch all tags on a resource",
                   response = TagModel.class)
     @ApiResponses(value = { @ApiResponse(code = 200, message = "Found the tags and returned in body"),
                             @ApiResponse(code = 401, message = "Invalid credentials provided"),
-                            @ApiResponse(code = 404, message = "Given specific comment not found"),
+                            @ApiResponse(code = 404, message = "Given specific resource not found"),
                             @ApiResponse(code = 500, message = "Internal server error occurred")})
     public Response getTags(@QueryParam("path") String resourcePath,
                             @QueryParam("start") int start,

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/swagger/SwaggerJaxrsConfig.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/swagger/SwaggerJaxrsConfig.java
@@ -1,0 +1,28 @@
+package org.wso2.carbon.registry.rest.api.swagger;
+
+import com.wordnik.swagger.jaxrs.config.BeanConfig;
+import org.wso2.carbon.utils.NetworkUtils;
+
+import javax.servlet.annotation.WebServlet;
+
+@WebServlet(name = "SwaggerJaxrsConfig", loadOnStartup = 1)
+public class SwaggerJaxrsConfig extends BeanConfig {
+
+    public SwaggerJaxrsConfig(){
+        super();
+    }
+
+    public void setBasePath(String basePath)
+    {
+        // Hostname
+        String hostName = "localhost";
+        try {
+            hostName = NetworkUtils.getMgtHostName();
+        } catch (Exception ignored) {
+        }
+
+        super.setBasePath("https://" +
+                          hostName + ":" + System.getProperty("mgt.transport.https.port") +
+                          "/resource/1.0.0");
+    }
+}

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/webapp/WEB-INF/beans.xml
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/webapp/WEB-INF/beans.xml
@@ -86,9 +86,9 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
         <property name="resourcePackage" value="org.wso2.carbon.registry.rest.api" />
         <property name="version" value="2.0" />
         <property name="basePath" value="https://localhost:9443/resource/1.0.0" />
-        <property name="title" value="Swagger UI Integration Sample" />
+        <property name="title" value="Swagger documentation for Governance registry REST API" />
         <property name="description"
-                  value="Swagger UI Integration Sample for demonstrating its working." />
+                  value="Swagger documentation for Governance registry REST API" />
         <property name="contact" value="dev@wso2.org" />
         <property name="scan" value="true" />
     </bean>

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/webapp/WEB-INF/beans.xml
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/webapp/WEB-INF/beans.xml
@@ -29,8 +29,11 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
 
     <import resource="classpath:META-INF/cxf/cxf.xml"/>
     <import resource="classpath:META-INF/cxf/cxf-servlet.xml"/>
+
     <context:property-placeholder/>
     <context:annotation-config/>
+	<!--<context:component-scan base-package="org.wso2.carbon.registry.rest.api" />-->
+
     <bean class="org.springframework.web.context.support.ServletContextPropertyPlaceholderConfigurer"/>
     <bean class="org.springframework.beans.factory.config.PreferencesPlaceholderConfigurer"/>
 
@@ -58,6 +61,37 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
             <bean class="org.wso2.carbon.registry.rest.api.handler.RestApiBasicAuthenticationHandler"/>
         </jaxrs:providers>
     </jaxrs:server>
+
+    <!-- Swagger API listing resource -->
+    <bean id="swaggerResourceJSON"
+          class="com.wordnik.swagger.jaxrs.listing.ApiListingResourceJSON" />
+
+    <!-- Swagger writers -->
+    <bean id="resourceWriter"
+          class="com.wordnik.swagger.jaxrs.listing.ResourceListingProvider" />
+    <bean id="apiWriter"
+          class="com.wordnik.swagger.jaxrs.listing.ApiDeclarationProvider" />
+
+    <jaxrs:server address="/swagger" id="swagger">
+        <jaxrs:serviceBeans>
+            <ref bean="swaggerResourceJSON" />
+        </jaxrs:serviceBeans>
+        <jaxrs:providers>
+            <ref bean="resourceWriter" />
+            <ref bean="apiWriter" />
+        </jaxrs:providers>
+    </jaxrs:server>
+
+    <bean id="swaggerConfig" class="org.wso2.carbon.registry.rest.api.swagger.SwaggerJaxrsConfig">
+        <property name="resourcePackage" value="org.wso2.carbon.registry.rest.api" />
+        <property name="version" value="2.0" />
+        <property name="basePath" value="https://localhost:9443/resource/1.0.0" />
+        <property name="title" value="Swagger UI Integration Sample" />
+        <property name="description"
+                  value="Swagger UI Integration Sample for demonstrating its working." />
+        <property name="contact" value="dev@wso2.org" />
+        <property name="scan" value="true" />
+    </bean>
 
 </beans>
 


### PR DESCRIPTION
After starting the G-Reg server users will be able to navigate to swagger doc of registry REST API by performing an HTTP get on following URL.

https://<server-name>:<https-port>/resource/1.0.0/swagger/api-docs
Ex - https://localhost:9443/resource/1.0.0/swagger/api-docs

This swagger doc can be added to G-Reg as a swagger artifact and use the embedded swagger UI view of G-Reg to view the documentation.

[1] https://wso2.org/jira/browse/REGISTRY-3029