### PR TITLE
Fix for REGISTRY-3603

### DIFF
--- a/components/registry/org.wso2.carbon.registry.extensions/src/main/java/org/wso2/carbon/registry/extensions/handlers/SwaggerMediaTypeHandler.java
+++ b/components/registry/org.wso2.carbon.registry.extensions/src/main/java/org/wso2/carbon/registry/extensions/handlers/SwaggerMediaTypeHandler.java
@@ -45,6 +45,7 @@ public class SwaggerMediaTypeHandler extends Handler {
 	private String swaggerLocation;
 	private String restServiceLocation;
 	private String endpointLocation;
+	private boolean createService = true;
 
 	/**
 	 * Extracts the common location for swagger docs from registry.xml entry
@@ -112,6 +113,22 @@ public class SwaggerMediaTypeHandler extends Handler {
 	}
 
 	/**
+	 * @return createService
+	 */
+	public boolean isCreateService() {
+		return createService;
+	}
+
+	/**
+	 * Extracts createService property from the registry.xml
+	 *
+	 * @param createService createService property
+	 */
+	public void setCreateService(String createService) {
+		this.createService = Boolean.valueOf(createService);
+	}
+
+	/**
 	 * Processes the PUT action for swagger files.
 	 *
 	 * @param requestContext        information about the current request.
@@ -146,14 +163,14 @@ public class SwaggerMediaTypeHandler extends Handler {
             String swaggerPath;
             if (StringUtils.isBlank(sourceURL)) {
                 inputStream = new ByteArrayInputStream((byte[]) resourceContentObj);
-                SwaggerProcessor processor = new SwaggerProcessor(requestContext, true);
+                SwaggerProcessor processor = new SwaggerProcessor(requestContext, isCreateService());
 				swaggerPath = processor
                         .processSwagger(inputStream, getChrootedLocation(requestContext.getRegistryContext()), null);
             } else {
                 //Open a stream to the sourceURL
                 inputStream = new URL(sourceURL).openStream();
 
-                SwaggerProcessor processor = new SwaggerProcessor(requestContext, true);
+                SwaggerProcessor processor = new SwaggerProcessor(requestContext, isCreateService());
 				swaggerPath = processor
                         .processSwagger(inputStream, getChrootedLocation(requestContext.getRegistryContext()),
                                 sourceURL);
@@ -200,7 +217,7 @@ public class SwaggerMediaTypeHandler extends Handler {
 			//Open a stream to the sourceURL
 			inputStream = new URL(sourceURL).openStream();
 
-			SwaggerProcessor processor = new SwaggerProcessor(requestContext, true);
+			SwaggerProcessor processor = new SwaggerProcessor(requestContext, isCreateService());
 			if(processor.processSwagger(inputStream, getChrootedLocation(requestContext.getRegistryContext()), sourceURL) != null) {
                 requestContext.setProcessingComplete(true);
             }

--- a/components/registry/org.wso2.carbon.registry.extensions/src/main/java/org/wso2/carbon/registry/extensions/handlers/WADLMediaTypeHandler.java
+++ b/components/registry/org.wso2.carbon.registry.extensions/src/main/java/org/wso2/carbon/registry/extensions/handlers/WADLMediaTypeHandler.java
@@ -39,6 +39,7 @@ public class WADLMediaTypeHandler extends Handler {
     private OMElement wadlLocationConfiguration;
     private String wadlLocation;
     private boolean disableWADLValidation = false;
+    private boolean createService = true;
 
 
     public OMElement getWADLLocationConfiguration() {
@@ -90,6 +91,22 @@ public class WADLMediaTypeHandler extends Handler {
         this.disableWADLValidation = Boolean.getBoolean(disableWADLValidation);
     }
 
+    /**
+     * @return createService
+     */
+    public boolean isCreateService() {
+        return createService;
+    }
+
+    /**
+     * Extracts createService property from the registry.xml
+     *
+     * @param createService createService property.
+     */
+    public void setCreateService(String createService) {
+        this.createService = Boolean.valueOf(createService);
+    }
+
     public void put(RequestContext requestContext) throws RegistryException {
         try{
             if (!CommonUtil.isUpdateLockAvailable()) {
@@ -101,6 +118,7 @@ public class WADLMediaTypeHandler extends Handler {
             requestContext.setSourceURL(
                     requestContext.getResource().getProperty(CommonConstants.SOURCEURL_PARAMETER_NAME));
             WADLProcessor wadlProcessor = new WADLProcessor(requestContext);
+            wadlProcessor.setCreateService(isCreateService());
             wadlProcessor.addWadlToRegistry(requestContext, resource,
                     resourcePath, disableWADLValidation);
             requestContext.setProcessingComplete(true);
@@ -116,6 +134,7 @@ public class WADLMediaTypeHandler extends Handler {
             }
             CommonUtil.acquireUpdateLock();
             WADLProcessor wadlProcessor = new WADLProcessor(requestContext);
+            wadlProcessor.setCreateService(isCreateService());
             wadlProcessor.importWADLToRegistry(requestContext, disableWADLValidation);
             requestContext.setProcessingComplete(true);
         } finally {

--- a/components/registry/org.wso2.carbon.registry.extensions/src/main/java/org/wso2/carbon/registry/extensions/handlers/ZipWSDLMediaTypeHandler.java
+++ b/components/registry/org.wso2.carbon.registry.extensions/src/main/java/org/wso2/carbon/registry/extensions/handlers/ZipWSDLMediaTypeHandler.java
@@ -120,6 +120,7 @@ public class ZipWSDLMediaTypeHandler extends WSDLMediaTypeHandler {
     private boolean disableWSDLValidation = false;
     private boolean disableSchemaValidation = false;
     private boolean useOriginalSchema = false;
+    private boolean createService = true;
 
     private boolean disableSymlinkCreation = true;
     private static int numberOfRetry = 5;
@@ -168,6 +169,22 @@ public class ZipWSDLMediaTypeHandler extends WSDLMediaTypeHandler {
             }
         }
         this.wadlLocationConfiguration = locationConfiguration;
+    }
+
+    /**
+     * @return createService
+     */
+    public boolean isCreateService() {
+        return createService;
+    }
+
+    /**
+     * Extracts createService property from the registry.xml
+     *
+     * @param createService createService property.
+     */
+    public void setCreateService(String createService) {
+        this.createService = Boolean.valueOf(createService);
     }
 
     public void put(RequestContext requestContext) throws RegistryException {
@@ -553,6 +570,7 @@ public class ZipWSDLMediaTypeHandler extends WSDLMediaTypeHandler {
             path = path + wadlName;
             requestContext.setResourcePath(new ResourcePath(path));
             WADLProcessor wadlProcessor = new WADLProcessor (requestContext);
+            wadlProcessor.setCreateService(isCreateService());
             return wadlProcessor.importWADLToRegistry(requestContext, disableWADLValidation);
 
         }
@@ -592,7 +610,7 @@ public class ZipWSDLMediaTypeHandler extends WSDLMediaTypeHandler {
             }
             path = path + swaggerName;
             requestContext.setResourcePath(new ResourcePath(path));
-            SwaggerProcessor swaggerProcessor = new SwaggerProcessor (requestContext, true);
+            SwaggerProcessor swaggerProcessor = new SwaggerProcessor (requestContext, isCreateService());
             InputStream inputStream = null;
             try {
                 inputStream = new URL(uri).openStream();


### PR DESCRIPTION
Functionality needed to provide the capability of adding a property in registry.xml to specify whether to create the service artifact or not is implemented in the media type handlers.