### PR TITLE
Encode content in resource text viewer/editor

### DIFF
--- a/components/registry/org.wso2.carbon.registry.resource.ui/src/main/resources/web/resources/display_text_content_ajaxprocessor.jsp
+++ b/components/registry/org.wso2.carbon.registry.resource.ui/src/main/resources/web/resources/display_text_content_ajaxprocessor.jsp
@@ -37,7 +37,7 @@
 %>
 <fmt:bundle basename="org.wso2.carbon.registry.resource.ui.i18n.Resources">
     <br/>
-    <textarea readonly="readonly" style="width:99%;height:200px"><%=textContent.replace("&", "&amp;")%></textarea>
+    <textarea readonly="readonly" style="width:99%;height:200px"><%=Encode.forHtml(textContent)%></textarea>
     <br/>
     <input type='button' class='button' id="cancelContentButtonID"
            onclick='cancelTextContentDisplay()'

--- a/components/registry/org.wso2.carbon.registry.resource.ui/src/main/resources/web/resources/edit_text_content_ajaxprocessor.jsp
+++ b/components/registry/org.wso2.carbon.registry.resource.ui/src/main/resources/web/resources/edit_text_content_ajaxprocessor.jsp
@@ -65,9 +65,9 @@
         <input id="editTextContentIDRichText1" type="radio" name="editTextContentIDRichText" <%=(showPlainText) ? "checked=\"checked\"" : "" %> value="plain" onclick="handleUpdateRichText()" /> <fmt:message key="plain.text.editor"/>
         <input id="editTextContentIDRichText0" type="radio" name="editTextContentIDRichText" <%=(showPlainText) ? "" : "checked=\"checked\"" %> <%=(hideRichText) ? "disabled=\"disabled\"" : "" %> value="rich" onclick="handleUpdateRichText()" /> <fmt:message key="rich.text.editor"/>
     </div>
-    <textarea id="editTextContentIDPlain" style="<%=(showPlainText) ? "" : "display:none;" %>width:99%;height:200px"><%=textContent.replace("&", "&amp;")%></textarea>
+    <textarea id="editTextContentIDPlain" style="<%=(showPlainText) ? "" : "display:none;" %>width:99%;height:200px"><%=Encode.forHtml(textContent)%></textarea>
     <div class="yui-skin-sam" id="editTextContentTextAreaPanel" <%=(showPlainText) ? "style=\"display:none\"" : "" %> >
-        <textarea id="editTextContentID" name="editTextContentID" style="display:none;"><%=textContent.replace("&", "&amp;")%></textarea>
+        <textarea id="editTextContentID" name="editTextContentID" style="display:none;"><%=Encode.forHtml(textContent)%></textarea>
     </div>
     <br/>
     <input type='button' class='button' id ="saveContentButtonID" onclick='updateTextContent("<%=path%>","<%=mediaType%>","false")'


### PR DESCRIPTION
## Purpose
To disallow registry resource viewer/editor disallowing running harmful client-side js scripts.

## Goals
This fix encodes the content (to be viewed from HTML) of the resources when reading from registry browser text viewer/editor disallowing running harmful client-side js scripts.
