### PR TITLE
Update zookeper dependency version

### DIFF
--- a/components/registry/org.wso2.carbon.registry.indexing/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.indexing/pom.xml
@@ -153,7 +153,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.zookeeper.wso2</groupId>
+            <groupId>org.wso2.orbit.org.apache.zookeeper</groupId>
             <artifactId>apache-zookeeper</artifactId>
             <scope>test</scope>
         </dependency>

--- a/features/content-search/org.wso2.carbon.registry.contentsearch.server.feature/pom.xml
+++ b/features/content-search/org.wso2.carbon.registry.contentsearch.server.feature/pom.xml
@@ -100,7 +100,7 @@
                                 <bundleDef>org.wso2.noggit:noggit</bundleDef>
                                 <bundleDef>org.wso2.orbit.org.restlet.jee:org.restlet</bundleDef>
                                 <bundleDef>org.wso2.orbit.org.apache.lucene:lucene</bundleDef>
-                                <bundleDef>org.apache.zookeeper.wso2:apache-zookeeper</bundleDef>
+                                <bundleDef>org.wso2.orbit.org.apache.zookeeper:apache-zookeeper</bundleDef>
                                 <bundleDef>com.wso2.spatial4j:spatial4j</bundleDef>
                                 <bundleDef>com.google.guava:guava</bundleDef>
                             </bundles>

--- a/pom.xml
+++ b/pom.xml
@@ -1304,7 +1304,7 @@
                 <version>${version.spatial4j}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.zookeeper.wso2</groupId>
+                <groupId>org.wso2.orbit.org.apache.zookeeper</groupId>
                 <artifactId>apache-zookeeper</artifactId>
                 <version>${version.zookeeper}</version>
             </dependency>
@@ -1583,7 +1583,7 @@
         <version.noggit>0.6.wso2v1</version.noggit>
         <version.org.restlet>2.3.0.wso2v1</version.org.restlet>
         <version.spatial4j>0.4.1.wso2v1</version.spatial4j>
-        <version.zookeeper>3.3.4.wso2v1</version.zookeeper>
+        <version.zookeeper>3.4.9.wso2v1</version.zookeeper>
         <derby.version>10.4.2.0</derby.version>
         <activation.version>1.1</activation.version>
         <javamail.version>1.4</javamail.version>


### PR DESCRIPTION
## Purpose
> This repo uses an old apache-zookeeper version. Created issue https://github.com/wso2/carbon-registry/issues/269 to track this.

## Goals
> To update apache-zookeeper to the latest orbit version