### PR TITLE
Fix storing a single value with a comma in the registry

### DIFF
--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Properties.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Properties.java
@@ -147,16 +147,15 @@ public class Properties extends PaginationCalculation<PropertyModel> {
     }
     private PropertyModel[] getPropertyModels(java.util.Properties properties) {
 
-        List<PropertyModel> list = new ArrayList<PropertyModel>();
+        List<PropertyModel> list = new ArrayList<>();
         Enumeration<Object> propName = properties.keys();
         while (propName.hasMoreElements()) {
             PropertyModel propModel = new PropertyModel();
             String property = propName.nextElement().toString();
-            String propValue = properties.get(property).toString();
-            propValue = propValue.substring(propValue.indexOf('[') + 1, propValue.indexOf(']'));
-            String[] propString = propValue.split(",");
+            ArrayList<String> propValue = (ArrayList<String>) properties.get(property);
+            String[] values = propValue.toArray(new String[propValue.size()]);
             propModel.setName(property);
-            propModel.setValue(propString);
+            propModel.setValue(values);
             list.add(propModel);
         }
         return list.toArray(new PropertyModel[list.size()]);

--- a/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Property.java
+++ b/components/registry/org.wso2.carbon.registry.rest.api/src/main/java/org/wso2/carbon/registry/rest/api/Property.java
@@ -40,6 +40,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Properties;
 
@@ -199,10 +200,10 @@ public class Property extends RegistryRestSuper {
      */
     private Response getSingleProperty(String propName, Properties prop) {
         HashMap<Object, Object> map = new HashMap<Object, Object>();
-        String propVal = prop.get(propName).toString();
-        propVal = propVal.substring(propVal.indexOf('[') + 1, propVal.lastIndexOf(']'));
-        String[] propValues = propVal.split(",");
-        map.put(propName, propValues);
+        ArrayList<String> propVal = (ArrayList<String>) prop.get(propName);
+        String[] values = propVal.toArray(new String[propVal.size()]);
+        map.put(propName, values);
+
         return Response.ok(map).build();
     }
 


### PR DESCRIPTION

## Purpose
> When storing a value with a comma in the registry, when making a GET request to the endpoint "/resource/1.0.0/properties" it returns an array with two values.
Resolves https://github.com/wso2/carbon-registry/issues/272.

## Goals
> Fixing the rest API for returning the property values.

## Approach
> Changed the splitting values using comma and now properties are returned as a object array.

## User stories
> Storing a single value with a comma in the registry.

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 N/A

## Security checks
 N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A