### PR TITLE
Fix solar indexing failure when parsing property values fail

### DIFF
--- a/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/solr/SolrClient.java
+++ b/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/solr/SolrClient.java
@@ -397,12 +397,24 @@ public class SolrClient {
         for (String propValue : values) {
             switch (valueType) {
                 case SolrConstants.TYPE_INT:
-                    intValue = Integer.parseInt(propValue);
-                    solrInputDocument.addField(fieldKey + SolrConstants.SOLR_MULTIVALUED_INT_FIELD_KEY_SUFFIX, intValue);
+                    try {
+                        intValue = Integer.parseInt(propValue);
+                        solrInputDocument.addField(fieldKey + SolrConstants.SOLR_MULTIVALUED_INT_FIELD_KEY_SUFFIX, intValue);
+                    } catch (NumberFormatException e) {
+                        log.debug("Number format error when parsing the value, Hence indexing as string value. Field:" +
+                                " " + fieldKey);
+                        solrInputDocument.addField(fieldKey + SolrConstants.SOLR_MULTIVALUED_STRING_FIELD_KEY_SUFFIX, propValue);
+                    }
                     break;
                 case SolrConstants.TYPE_DOUBLE:
-                    doubleValue = Double.parseDouble(propValue);
-                    solrInputDocument.addField(fieldKey + SolrConstants.SOLR_MULTIVALUED_DOUBLE_FIELD_KEY_SUFFIX, doubleValue);
+                    try {
+                        doubleValue = Double.parseDouble(propValue);
+                        solrInputDocument.addField(fieldKey + SolrConstants.SOLR_MULTIVALUED_DOUBLE_FIELD_KEY_SUFFIX, doubleValue);
+                    } catch (NumberFormatException e) {
+                        log.debug("Number format error when parsing the value, Hence indexing as string value. Field:" +
+                                " " + fieldKey);
+                        solrInputDocument.addField(fieldKey + SolrConstants.SOLR_MULTIVALUED_STRING_FIELD_KEY_SUFFIX, propValue);
+                    }
                     break;
                 case SolrConstants.TYPE_STRING:
                     solrInputDocument.addField(fieldKey + SolrConstants.SOLR_MULTIVALUED_STRING_FIELD_KEY_SUFFIX, propValue);


### PR DESCRIPTION
## Purpose
Solr indexing fails if the property value cannot be parsed to the defined type such as INT, DOUBLE etc. Moreover, long type values are parsed as INT type.
Better to default to string type and support indexing if parsing fails.

## Goals
Solr indexing fails if the property value cannot be parsed to the defined type such as INT, DOUBLE etc. Moreover, long type values are parsed as INT type.
Better to default to string type and support indexing if parsing fails.

## Approach
Solr indexing fails if the property value cannot be parsed to the defined type such as INT, DOUBLE etc. Moreover, long type values are parsed as INT type.
Better to default to string type and support indexing if parsing fails.
So if the value is an above-mentioned type and indexing fails, we consider it as string value when indexing the resource.

## User stories
NA

## Release note
NA

## Documentation
NA

## Training
NA

## Marketing
NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
NA

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
java version "1.7.0_80"
Java(TM) SE Runtime Environment (build 1.7.0_80-b15)
Java HotSpot(TM) 64-Bit Server VM (build 24.80-b11, mixed mode)
 
## Learning
NA