### PR TITLE
Fix unit test failure due to log dependency conflict

### DIFF
--- a/components/registry/org.wso2.carbon.registry.indexing/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.indexing/pom.xml
@@ -153,11 +153,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.noggit</groupId>
             <artifactId>noggit</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Purpose
To fix unit test failures in indexing module. Unit test fails due to conflict in logging library which is packed with zookeeper library.

## Goals
To fix unit test failures in indexing module. Unit test fails due to conflict in logging library which is packed with zookeeper library.

## Approach
Remove zookeeper test dependency from the module. This was used only for unit testing and we are not actually using it.

## User stories
no change

## Release note
this fix is for unit test failures.

## Documentation
N/A, this fix is for unit test failures.

## Training
N/A, this fix is for unit test failures.

## Certification
N/A, this fix is for unit test failures.

## Marketing
N/A, this fix is for unit test failures.

## Automation tests
 - Unit tests 
   this fix is for unit test failures.
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A. this fix is for unit test failures.

## Related PRs
No

## Migrations (if applicable)
N/A. this fix is for unit test failures.

## Test environment
Linux Ubuntu 16.04 with jdk 8
 
## Learning
No