### PR TITLE
Add entry to support with JDK 11

### DIFF
--- a/components/registry/org.wso2.carbon.registry.admin.api/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.admin.api/pom.xml
@@ -86,6 +86,7 @@
                             org.wso2.carbon.registry.admin.api.*;version="0.0.0"
                         </Export-Package>
                         <Import-Package>
+                            javax.activation.*;version="[0.0.0, 1.0.0)",
                             org.wso2.carbon.registry.core.*;version="${carbon.kernel.registry.imp.pkg.version}",
                             !javax.xml.namespace,
                             javax.xml.namespace; version=0.0.0,

--- a/pom.xml
+++ b/pom.xml
@@ -1368,6 +1368,11 @@
                 <version>${powermock.version}</version>
                 <scope>test</scope>
             </dependency>
+                <dependency>
+                <groupId>org.wso2.orbit.javax.activation</groupId>
+                <artifactId>activation</artifactId>
+                <version>${version.org.wso2.orbit.javax.activation}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1612,6 +1617,7 @@
         <orbit.version.xmlschema>1.4.7.wso2v2</orbit.version.xmlschema>
         <orbit.version.infinispan>5.1.2.wso2v1</orbit.version.infinispan>
         <orbit.version.h2.engine>1.3.175.wso2v1</orbit.version.h2.engine>
+        <version.org.wso2.orbit.javax.activation>1.1.1.wso2v1</version.org.wso2.orbit.javax.activation>
 
         <!-- Abdera -->
         <version.abdera>1.0-wso2v2</version.abdera>


### PR DESCRIPTION
## Purpose
>javax.activation is removed from JDK 11. add it as a orbit to work with jdk 11 products 