### PR TITLE
Add support for jdk11

### DIFF
--- a/components/registry/org.wso2.carbon.registry.extensions.ui/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.extensions.ui/pom.xml
@@ -44,6 +44,7 @@
                             org.wso2.carbon.registry.extensions.ui.*,
                         </Export-Package>
                         <Import-Package>
+                            javax.activation.*;version="[0.0.0, 1.0.0)",
                             org.wso2.carbon.registry.common.ui.*;version="0.0.0",
                             org.wso2.carbon.registry.core.*;version="${carbon.kernel.registry.imp.pkg.version}",
                             !javax.xml.namespace,

--- a/components/registry/org.wso2.carbon.registry.extensions/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.extensions/pom.xml
@@ -96,6 +96,7 @@
                             org.wso2.carbon.registry.extensions.*,
                         </Private-Package>
                         <Import-Package>
+                            javax.activation.*;version="[0.0.0, 1.0.0)",
                             org.wso2.carbon.registry.core.*;version="${carbon.kernel.registry.imp.pkg.version}",
                             org.wso2.carbon.ui.*;version="${carbon.kernel.package.import.version.range}",
                             org.apache.maven.scm.*,

--- a/components/registry/org.wso2.carbon.registry.reporting.ui/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.reporting.ui/pom.xml
@@ -43,6 +43,7 @@
                             org.wso2.carbon.registry.reporting.ui.*,
                         </Export-Package>
                         <Import-Package>
+                            javax.activation.*;version="[0.0.0, 1.0.0)",
                             org.wso2.carbon.registry.common.ui.*;version="0.0.0",
                             org.wso2.carbon.registry.core.*;version="${carbon.kernel.registry.imp.pkg.version}",
                             !javax.xml.namespace,

--- a/components/registry/org.wso2.carbon.registry.resource.ui/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.resource.ui/pom.xml
@@ -43,6 +43,7 @@
                             org.wso2.carbon.registry.resource.ui.*
                         </Export-Package>
                         <Import-Package>
+                            javax.activation.*;version="[0.0.0, 1.0.0)",
                             org.wso2.carbon.registry.common.ui.*;version="0.0.0",
                             org.wso2.carbon.registry.common.*;version="0.0.0",
                             org.wso2.carbon.registry.core.*;version="${carbon.kernel.registry.imp.pkg.version}",

--- a/components/registry/org.wso2.carbon.registry.resource/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.resource/pom.xml
@@ -51,6 +51,7 @@
                             org.wso2.carbon.registry.resource.*,
                         </Export-Package>
                         <Import-Package>
+                            javax.activation.*;version="[0.0.0, 1.0.0)",
                             org.wso2.carbon.registry.common.*;version="0.0.0",
                             org.wso2.carbon.registry.core.*;version="${carbon.kernel.registry.imp.pkg.version}",
                             !javax.xml.namespace,

--- a/components/registry/org.wso2.carbon.registry.social.impl/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.social.impl/pom.xml
@@ -92,6 +92,7 @@
                             org.wso2.carbon.registry.social.impl.*; version=1.0.0,
                         </Export-Package>
                         <Import-Package>
+                            javax.activation.*;version="[0.0.0, 1.0.0)",
                             org.apache.axis2.*; version="${axis2.osgi.version.range}",
                             javax.servlet.http;version="${imp.pkg.version.javax.servlet}",
                             org.wso2.carbon.registry.social.impl.common.*,

--- a/components/registry/org.wso2.carbon.registry.ws.api/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.ws.api/pom.xml
@@ -93,6 +93,7 @@
                             org.wso2.carbon.registry.ws.api.*;
                         </Export-Package>
                         <Import-Package>
+                            javax.activation.*;version="[0.0.0, 1.0.0)",
                             org.wso2.carbon.registry.core.*;version="${carbon.kernel.registry.imp.pkg.version}",
                             org.apache.axis2.*; version="${axis2.osgi.version.range}",
                             org.apache.commons.logging.*,

--- a/components/registry/org.wso2.carbon.registry.ws.client/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.ws.client/pom.xml
@@ -47,6 +47,7 @@
                         org.wso2.carbon.registry.ws.client.*;version="0.0.0",
                         </Export-Package>
                         <Import-Package>
+                            javax.activation.*;version="[0.0.0, 1.0.0)",
                             org.wso2.carbon.registry.core.*;version="${carbon.kernel.registry.imp.pkg.version}",
                             !javax.xml.namespace,
                             javax.xml.namespace; version=0.0.0,


### PR DESCRIPTION
## Purpose
> Add support for jdk11. javax.activation is removed from jdk 11. manually import it 