### PR TITLE
Make carbon-registry buildable in Java 11

### DIFF
--- a/components/registry/org.wso2.carbon.registry.admin.api/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.admin.api/pom.xml
@@ -51,9 +51,11 @@
                                         <plugin>
                                             <groupId>org.apache.maven.plugins</groupId>
                                             <artifactId>maven-javadoc-plugin</artifactId>
-                                            <version>2.9</version>
+                                            <version>3.1.1</version>
                                             <configuration>
-                                                <additionalparam>-Xdoclint:none</additionalparam>
+                                                <source>1.8</source>
+                                                <!--This parameter disables doclint-->
+                                                <doclint>none</doclint>
                                                 <links>
                                                     <link>http://java.sun.com/j2se/1.5/docs/api/</link>
                                                 </links>
@@ -113,8 +115,10 @@
                                 <plugin>
                                     <groupId>org.apache.maven.plugins</groupId>
                                     <artifactId>maven-javadoc-plugin</artifactId>
-                                    <version>2.9</version>
+                                    <version>3.1.1</version>
                                     <configuration>
+                                        <!--This parameter disables doclint-->
+                                        <doclint>none</doclint>
                                         <links>
                                             <link>http://java.sun.com/j2se/1.5/docs/api/</link>
                                         </links>

--- a/components/registry/org.wso2.carbon.registry.indexing/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.indexing/pom.xml
@@ -76,7 +76,7 @@
                 <inherited>true</inherited>
                 <configuration>
                     <forkMode>pertest</forkMode>
-                    <argLine>-XX:-UseSplitVerifier ${argLine} -enableassertions -noverify</argLine>
+                    <argLine>${argLine} -enableassertions -noverify</argLine>
                     <testFailureIgnore>true</testFailureIgnore>
                 </configuration>
             </plugin>

--- a/components/registry/org.wso2.carbon.registry.rest.api/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.rest.api/pom.xml
@@ -119,6 +119,13 @@
             <artifactId>slf4j-log4j12</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.4.0-b180830.0359</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
     <build>
             <plugins>

--- a/components/registry/org.wso2.carbon.registry.security/src/main/java/org/wso2/carbon/registry/security/vault/util/SecureVaultUtil.java
+++ b/components/registry/org.wso2.carbon.registry.security/src/main/java/org/wso2/carbon/registry/security/vault/util/SecureVaultUtil.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.util.Base64;
 import java.util.Properties;
 
 import org.apache.axis2.AxisFault;
@@ -37,7 +38,6 @@ import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.core.session.UserRegistry;
 import org.wso2.carbon.registry.security.vault.CipherInitializer;
 import org.wso2.carbon.registry.security.vault.internal.SecurityServiceHolder;
-import sun.misc.BASE64Encoder;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -98,8 +98,8 @@ public class SecureVaultUtil {
                 }
             }
             byte[] encryptedPassword = cipher.doFinal(plainTextPassByte);
-            BASE64Encoder encoder = new BASE64Encoder();
-            String encodedValue = encoder.encode(encryptedPassword);
+            Base64.Encoder encoder = Base64.getEncoder();
+            String encodedValue = new String(encoder.encode(encryptedPassword));
             return encodedValue;
         } catch (IllegalBlockSizeException e) {
             handleException(log, "Error encrypting password ", e);

--- a/components/registry/org.wso2.carbon.registry.social.api/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.social.api/pom.xml
@@ -71,9 +71,10 @@
                                         <plugin>
                                             <groupId>org.apache.maven.plugins</groupId>
                                             <artifactId>maven-javadoc-plugin</artifactId>
-                                            <version>2.9</version>
+                                            <version>3.1.1</version>
                                             <configuration>
-                                                <additionalparam>-Xdoclint:none</additionalparam>
+                                                <source>1.8</source>
+                                                <doclint>none</doclint>
                                                 <links>
                                                     <link>http://java.sun.com/j2se/1.5/docs/api/</link>
                                                 </links>

--- a/components/registry/org.wso2.carbon.registry.webdav/src/main/java/org/wso2/carbon/registry/webdav/RegistryServlet.java
+++ b/components/registry/org.wso2.carbon.registry.webdav/src/main/java/org/wso2/carbon/registry/webdav/RegistryServlet.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.registry.webdav;
 
 import java.io.IOException;
+import java.util.Base64;
 
 import javax.jcr.Repository;
 import javax.servlet.ServletException;
@@ -176,8 +177,8 @@ public class RegistryServlet extends SimpleWebdavServlet {
 		String userpassEncoded = auth.substring(6);
 
 		// Decode it, using any base 64 decoder
-		sun.misc.BASE64Decoder dec = new sun.misc.BASE64Decoder();
-		String userpassDecoded = new String(dec.decodeBuffer(userpassEncoded));
+		Base64.Decoder dec = Base64.getDecoder();
+		String userpassDecoded = new String(dec.decode(userpassEncoded));
 		return userpassDecoded.split(":");
 	}
 

--- a/components/registry/org.wso2.carbon.registry.ws.api/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.ws.api/pom.xml
@@ -50,9 +50,10 @@
                                         <plugin>
                                             <groupId>org.apache.maven.plugins</groupId>
                                             <artifactId>maven-javadoc-plugin</artifactId>
-                                            <version>2.9</version>
+                                            <version>3.1.1</version>
                                             <configuration>
-                                                <additionalparam>-Xdoclint:none</additionalparam>
+                                                <source>1.8</source>
+                                                <doclint>none</doclint>
                                                 <links>
                                                     <link>http://java.sun.com/j2se/1.5/docs/api/</link>
                                                 </links>


### PR DESCRIPTION
## Purpose
Make carbon-registry buildable in Java 11

## Goals
Make carbon-registry buildable in Java 11

## Approach
Make carbon-registry buildable in Java 11

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A