### PR TITLE
Fix https://github.com/wso2/product-apim/issues/6476

### DIFF
--- a/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/RegistryConfigLoader.java
+++ b/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/RegistryConfigLoader.java
@@ -54,6 +54,8 @@ public class RegistryConfigLoader {
 
     private String lastAccessTimeLocation;
 
+    private String skipRolesByRegex;
+
     private Map<String, Indexer> indexerMap = new LinkedHashMap<String, Indexer>();
 
     private List<Pattern> exclusionList = new ArrayList<Pattern>();
@@ -145,6 +147,10 @@ public class RegistryConfigLoader {
         return startingDelayInSecs;
     }
 
+    public String getSkipRolesByRegex() {
+        return skipRolesByRegex;
+    }
+
     // Get registry.xml instance.
     private static File getConfigFile() throws RegistryException {
         String configPath = CarbonUtils.getRegistryXMLPath();
@@ -210,6 +216,16 @@ public class RegistryConfigLoader {
         } catch (OMException e) {
             // we can use default value and continue if no OMElement found in indexingConfig
             log.error("Error occurred when retrieving skipCache info, hence using the default value", e);
+        }
+
+        try {
+            OMElement skipRolesByRegexElemet = indexingConfig.getFirstChildWithName(new QName("skipRolesByRegex"));
+            if (skipRolesByRegexElemet != null) {
+                skipRolesByRegex = skipRolesByRegexElemet.getText();
+            }
+        } catch (OMException e) {
+            // we can use default value and continue if no OMElement found in indexingConfig
+            log.error("Error occurred when retrieving skipRolesByRegex, hence using the default value", e);
         }
         
         // solr server url for initiate the solr server	


### PR DESCRIPTION
## Purpose
This PR fixes the error reported in https://github.com/wso2/product-apim/issues/6476

## Approach
Error `Caused by: org.apache.lucene.search.BooleanQuery$TooManyClauses: maxClauseCount is set to 1024` occurs when the solr query has more than 1024 clauses. 
when a user has many application roles (used for internal APIM functionalities) all these roles are appended to the solr search query and it is possible the clause count becomes greater than 1024 in a situation like this. 
As the solution here we are adding the support for optionally skipping 'Application/*' roles in the search query.

<skipRolesByRegex>Application\/.*</skipRolesByRegex> 
