### PR TITLE
Remove central repositroy from CMIS pom file.

### DIFF
--- a/components/registry/org.wso2.carbon.registry.cmis/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.cmis/pom.xml
@@ -102,12 +102,4 @@
         </dependency>
     </dependencies>
 
-    <repositories>
-        <repository>
-            <id>maven2-repo</id>
-            <name>Maven Repository for Maven</name>
-            <url>http://repo1.maven.org/maven2</url>
-        </repository>
-    </repositories>
-
 </project>


### PR DESCRIPTION

## Purpose
> Remove central repository from CMIS pom file to fetch artifacts from
WSO2 Nexus.
