### PR TITLE
Dependancy version update of commons-io.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1629,7 +1629,7 @@
         <!-- Misc -->
         <google.guava.wso2.version>27.0-jre</google.guava.wso2.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
-        <version.solr>5.5.5.wso2v1</version.solr>
+        <version.solr>5.5.5.wso2v2</version.solr>
         <version.solr.import.version.range>[5.5.5,5.6.0)</version.solr.import.version.range>
         <version.lucene>5.5.5.wso2v1</version.lucene>
         <version.httpclient>4.3.6.wso2v3</version.httpclient>
@@ -1696,7 +1696,7 @@
         <commons-collections.version>3.2</commons-collections.version>
         <commons-digester.version>1.8</commons-digester.version>
         <orbit.version.commons.beanutils>1.8.0.wso2v1</orbit.version.commons.beanutils>
-        <commons-io.wso2.version>2.4.0.wso2v1</commons-io.wso2.version>
+        <commons-io.wso2.version>2.7.0.wso2v1</commons-io.wso2.version>
         <commons-fileupload.version>1.1.1</commons-fileupload.version>
         <orbit.version.commons.httpclient>3.1.0.wso2v6</orbit.version.commons.httpclient>
         <commons-dbcp.version>1.2.2</commons-dbcp.version>


### PR DESCRIPTION
Related Issues: wso2/product-is#12485
## Purpose
> Update commons-io version to 2.7.0.wso2v1

Depends on https://github.com/wso2/carbon-registry/pull/370