### PR TITLE
Upgrade SSL context protocol to TLSv1.2

### DIFF
--- a/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/solr/EasySSLProtocolSocketFactory.java
+++ b/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/solr/EasySSLProtocolSocketFactory.java
@@ -100,7 +100,7 @@ public class EasySSLProtocolSocketFactory implements SecureProtocolSocketFactory
 
     private static SSLContext createEasySSLContext() {
         try {
-            SSLContext context = SSLContext.getInstance("SSL");
+            SSLContext context = SSLContext.getInstance("TLSv1.2");
             context.init(
               null, 
               new TrustManager[] {new EasyX509TrustManager(null)}, 


### PR DESCRIPTION
The SSL context protocol should be upgraded to a more secure protocol to fix "Selection of Less-Secure Algorithm During Negotiation" security vulnerabilities.