### PR TITLE
Bump the POI version to 5.2.5.wso2v1

### DIFF
--- a/components/registry/org.wso2.carbon.registry.indexing/pom.xml
+++ b/components/registry/org.wso2.carbon.registry.indexing/pom.xml
@@ -113,8 +113,12 @@
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.poi.wso2</groupId>
+            <groupId>org.wso2.orbit.org.apache.poi</groupId>
             <artifactId>poi-scratchpad</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>

--- a/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/indexer/MSPowerpointIndexer.java
+++ b/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/indexer/MSPowerpointIndexer.java
@@ -17,17 +17,19 @@
  */
 package org.wso2.carbon.registry.indexing.indexer;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.poi.hslf.extractor.PowerPointExtractor;
-import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.apache.poi.hslf.usermodel.HSLFSlideShow;
+import org.apache.poi.poifs.filesystem.OfficeXmlFileException;
+import org.apache.poi.sl.extractor.SlideShowExtractor;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.wso2.carbon.registry.indexing.AsyncIndexer.File2Index;
 import org.wso2.carbon.registry.indexing.solr.IndexDocument;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 
 public class MSPowerpointIndexer implements Indexer {
 
@@ -35,18 +37,27 @@ public class MSPowerpointIndexer implements Indexer {
 	
 	public IndexDocument getIndexedDocument(File2Index fileData)
 			throws SolrException {
+		String ppText = null;
 		try {
-			POIFSFileSystem fs = new POIFSFileSystem(new ByteArrayInputStream(fileData.data));
-			PowerPointExtractor extractor = new PowerPointExtractor(fs);
-			String ppText = extractor.getText();
-
-			return new IndexDocument(fileData.path, ppText, null);
+			HSLFSlideShow slideShow = new HSLFSlideShow(new ByteArrayInputStream(fileData.data));
+			SlideShowExtractor<?, ?> extractor = new SlideShowExtractor <>(slideShow);
+			ppText = extractor.getText();
+		} catch (OfficeXmlFileException e){
+			try {
+				XMLSlideShow slideShow = new XMLSlideShow(new ByteArrayInputStream(fileData.data));
+				SlideShowExtractor<?, ?> extractor = new SlideShowExtractor <>(slideShow);
+				ppText = extractor.getText();
+			} catch (IOException e1) {
+				String msg = "Failed to write to the index";
+				log.error(msg, e);
+				throw new SolrException(ErrorCode.SERVER_ERROR, msg);
+			}
 		} catch (IOException e) {
 			String msg = "Failed to write to the index";
 			log.error(msg, e);
 			throw new SolrException(ErrorCode.SERVER_ERROR, msg);
 		}
-
+		return new IndexDocument(fileData.path, ppText, null);
 	}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1694,7 +1694,7 @@
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-digester.version>1.8</commons-digester.version>
         <orbit.version.commons.beanutils>1.8.0.wso2v1</orbit.version.commons.beanutils>
-        <commons-io.wso2.version>2.7.0.wso2v1</commons-io.wso2.version>
+        <commons-io.wso2.version>2.15.1.wso2v1</commons-io.wso2.version>
         <commons-fileupload.version>1.1.1</commons-fileupload.version>
         <orbit.version.commons.httpclient>3.1.0.wso2v6</orbit.version.commons.httpclient>
         <commons-dbcp.version>1.2.2</commons-dbcp.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1299,8 +1299,13 @@
                 <version>${version.httpmime}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.poi.wso2</groupId>
+                <groupId>org.wso2.orbit.org.apache.poi</groupId>
                 <artifactId>poi-scratchpad</artifactId>
+                <version>${apache.poi.wso2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.apache.poi</groupId>
+                <artifactId>poi-ooxml</artifactId>
                 <version>${apache.poi.wso2.version}</version>
             </dependency>
             <dependency>
@@ -1702,7 +1707,7 @@
         <jackson.version>1.9.13</jackson.version>
         <amber.version>0.22.1358727-wso2v2</amber.version>
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
-        <apache.poi.wso2.version>3.9.0.wso2v1</apache.poi.wso2.version>
+        <apache.poi.wso2.version>5.2.5.wso2v1</apache.poi.wso2.version>
 
         <!-- Pax logging -->
         <pax.logging.api.version>1.10.1</pax.logging.api.version>


### PR DESCRIPTION
## Purpose

This PR adds the following changes,
- [Bump commons-io version to 2.15.1.wso2v1](https://github.com/wso2/carbon-registry/commit/4396ce5e09c8d90bf2453c04b1ad8cfe40ec0caf)
- [Bump poi version to 5.2.5.wso2v1](https://github.com/wso2/carbon-registry/commit/d741d8890b0ddb3e31cfc3e4f2b4f2fdcaeb5020)