### PR TITLE
Add extension point to preprocess data before indexing

### DIFF
--- a/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/AsyncIndexer.java
+++ b/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/AsyncIndexer.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.registry.core.config.RegistryContext;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.indexing.indexer.IndexDocumentCreator;
 import org.wso2.carbon.registry.indexing.indexer.IndexerException;
+import org.wso2.carbon.registry.indexing.indexer.IndexerPreProcessor;
 import org.wso2.carbon.registry.indexing.solr.SolrClient;
 import org.wso2.carbon.utils.WaitBeforeShutdownObserver;
 
@@ -240,6 +241,12 @@ public class AsyncIndexer implements Runnable {
                     Resource resource;
                     //Check whether resource exists before indexing the resource
                     if (registry.resourceExists(resourcePath) && (resource = registry.get(resourcePath)) != null) {
+                        
+                        // Process resource before index document is created
+                        if (Utils.getIndexerPreprocessor() != null) {
+                            IndexerPreProcessor preprocessor = Utils.getIndexerPreprocessor();
+                            preprocessor.processResource(resource);
+                        }
                         // Create the IndexDocument
                         IndexDocumentCreator indexDocumentCreator = new IndexDocumentCreator(file2Index, resource);
                         indexDocumentCreator.createIndexDocument();

--- a/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/Utils.java
+++ b/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/Utils.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.registry.core.RegistryConstants;
 import org.wso2.carbon.registry.core.config.RegistryConfigurationProcessor;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.core.service.RegistryService;
+import org.wso2.carbon.registry.indexing.indexer.IndexerPreProcessor;
 import org.wso2.carbon.registry.indexing.internal.IndexingServiceComponent;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.WaitBeforeShutdownObserver;
@@ -57,6 +58,8 @@ public class Utils {
     private static String remoteTopicHeaderNS;
 
     private static String remoteSubscriptionStoreContext;
+    
+    private static IndexerPreProcessor preprocessor;
 
     public static void setRegistryService(RegistryService service) {
         registryService = service;
@@ -179,5 +182,13 @@ public class Utils {
             throw new RegistryException(msg);
         }
         return false;
+    }
+
+    public static IndexerPreProcessor getIndexerPreprocessor() {
+        return preprocessor;
+    }
+
+    public static void setIndexerPreprocessor(IndexerPreProcessor preprocessor) {
+        Utils.preprocessor = preprocessor;
     }
 }

--- a/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/indexer/IndexerPreProcessor.java
+++ b/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/indexer/IndexerPreProcessor.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.registry.indexing.indexer;
+
+
+import org.wso2.carbon.registry.core.Resource;
+import org.wso2.carbon.registry.core.exceptions.RegistryException;
+
+/**
+ * Interface is provided to manupilate registry resource before it is indexed
+ */
+public interface IndexerPreProcessor {
+    
+    public void processResource(Resource resource) throws RegistryException;
+
+}

--- a/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/internal/IndexingServiceComponent.java
+++ b/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/internal/IndexingServiceComponent.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.registry.core.session.UserRegistry;
 import org.wso2.carbon.registry.indexing.IndexingManager;
 import org.wso2.carbon.registry.indexing.Utils;
 import org.wso2.carbon.registry.indexing.indexer.IndexerException;
+import org.wso2.carbon.registry.indexing.indexer.IndexerPreProcessor;
 import org.wso2.carbon.registry.indexing.service.*;
 import org.wso2.carbon.utils.AbstractAxis2ConfigurationContextObserver;
 import org.wso2.carbon.utils.Axis2ConfigurationContextObserver;
@@ -310,6 +311,21 @@ public class IndexingServiceComponent {
 
     public static boolean canIndexTenant(int tenantId) {
         return tenantId == MultitenantConstants.SUPER_TENANT_ID || initializedTenants.containsKey(tenantId);
+    }
+    
+    @Reference(
+            name = "registry.indexer.preprocessor", 
+            service = org.wso2.carbon.registry.indexing.indexer.IndexerPreProcessor.class, 
+            cardinality = ReferenceCardinality.OPTIONAL, 
+            policy = ReferencePolicy.DYNAMIC, 
+            unbind = "unsetIndexerPreProcessor")
+    protected void setIndexerPreProcessor(IndexerPreProcessor preprocesor) {
+        Utils.setIndexerPreprocessor(preprocesor);
+    }
+
+    protected void unsetIndexerPreProcessor(IndexerPreProcessor preprocesor) {
+        stopIndexing();
+        Utils.setIndexerPreprocessor(null);
     }
 }
 


### PR DESCRIPTION
## Purpose
Currently there is no mechanism to process registry resource before it is added to the indexing document. With this pr, I have introduced a new interface `IndexerPreProcessor.java` where we can plug a custom implementation to preprocess the resource before indexing. 

With this introduction, In APIM, we prevent registry data migration when when introduce a new property or field to the API