### PR TITLE
Improvement to IndexDocumentCreator

### DIFF
--- a/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/indexer/IndexDocumentCreator.java
+++ b/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/indexer/IndexDocumentCreator.java
@@ -160,7 +160,15 @@ public class IndexDocumentCreator {
             }
         }
         if (propertyList.size() > 0) {
-            attributes.put(IndexingConstants.FIELD_PROPERTY_VALUES, propertyList);
+            if (attributes.containsKey(IndexingConstants.FIELD_PROPERTY_VALUES)) {
+                List<String> existingList = attributes.get(IndexingConstants.FIELD_PROPERTY_VALUES);
+                List<String> combinedList = new ArrayList<>();
+                combinedList.addAll(existingList);
+                combinedList.addAll(propertyList);
+                attributes.put(IndexingConstants.FIELD_PROPERTY_VALUES, combinedList);
+            } else {
+                attributes.put(IndexingConstants.FIELD_PROPERTY_VALUES, propertyList);
+            } 
         }
     }
 


### PR DESCRIPTION
## Purpose
Currently we cannot override registry propertie data in the indexdocumentcreator (https://github.com/wso2/carbon-registry/blob/master/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/indexer/IndexDocumentCreator.java#L123) . Whatever fields sent from a custom index document https://github.com/wso2/carbon-registry/blob/master/components/registry/org.wso2.carbon.registry.indexing/src/main/java/org/wso2/carbon/registry/indexing/indexer/IndexDocumentCreator.java#L123 is overridden. This fix stop this overriding part