### PR TITLE
Add comment for guava related dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1635,6 +1635,8 @@
         <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>
 
         <!-- Misc -->
+        <!--Please make sure to update the Guava and Guava FailureAccess versions in the carbon-kernel repository as
+        well.-->
         <google.guava.wso2.version>33.0.0-jre</google.guava.wso2.version>
         <google.guava.failureaccess.version>1.0.2</google.guava.failureaccess.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>


### PR DESCRIPTION
## Purpose

Since guava and guava failure access jars are also packed from the carbon-kernel with [1], we need to make sure that the versions are upgrade at both the locations, if not it could cause multiple JAR versions to get packed to the product.

[1] - https://github.com/wso2/carbon-kernel/pull/4339 

## Goals

Inform developers to bump dependency versions in all the locations. Partially fixes: https://github.com/wso2/product-is/issues/24653.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 -  Ran FindSecurityBugs plugin and verified report? yes
 -  Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes