### PR TITLE
[Bump] Solr version to 9.5.0.wso2v8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1638,7 +1638,7 @@
         <google.guava.wso2.version>33.0.0-jre</google.guava.wso2.version>
         <google.guava.failureaccess.version>1.0.2</google.guava.failureaccess.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
-        <version.solr>9.5.0.wso2v7</version.solr>
+        <version.solr>9.5.0.wso2v8</version.solr>
         <version.solr.import.version.range>[9.0.0,10.0.0)</version.solr.import.version.range>
         <version.httpclient>4.5.13.wso2v1</version.httpclient>
         <version.httpmime>4.5.13.wso2v1</version.httpmime>


### PR DESCRIPTION
Bump solr from solr_9.5.0.wso2v7 to solr_9.5.0.wso2v8.

### Related PRs
  - https://github.com/wso2/orbit/pull/1237
  - https://github.com/wso2-support/orbit/pull/449

## Related Issues
  - https://github.com/wso2/product-is/issues/24905